### PR TITLE
[WIP] Picker experiments

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -13,6 +13,7 @@ import ChatHeads from './chatHeads';
 import Code from './code';
 import WidthAndHeight from './widthAndHeight';
 import Rotations from './rotations';
+import Picker from './picker';
 
 YellowBox.ignoreWarnings([
   'Warning: isMounted(...) is deprecated',
@@ -22,6 +23,7 @@ YellowBox.ignoreWarnings([
 // https://github.com/react-navigation/react-navigation/issues/3956
 
 const SCREENS = {
+  picker: { screen: Picker, title: 'Picker' },
   Snappable: { screen: Snappable, title: 'Snappable' },
   Test: { screen: Test, title: 'Test' },
   ImageViewer: { screen: ImageViewer, title: 'Image Viewer' },

--- a/Example/picker/index.js
+++ b/Example/picker/index.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, { Easing } from 'react-native-reanimated';
+import { PanGestureHandler, State } from 'react-native-gesture-handler';
+
+const {
+  add,
+  divide,
+  ceil,
+  floor,
+  greaterOrEq,
+  or,
+  multiply,
+  block,
+  call,
+  cond,
+  Clock,
+  event,
+  eq,
+  set,
+  timing,
+  Value,
+  clockRunning,
+  startClock,
+  stopClock,
+} = Animated;
+
+const VALUE_HEIGHT = 50;
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  thing: {
+    height: VALUE_HEIGHT,
+    width: VALUE_HEIGHT,
+    backgroundColor: 'red',
+  },
+  stripes: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+  stripe: {
+    alignSelf: 'stretch',
+    borderBottomWidth: 1,
+    borderBottomColor: 'black',
+    height: VALUE_HEIGHT,
+  },
+})
+
+const runSnap = (clock, yPositionOnRelease, dragY) => {
+  const state = {
+    finished: new Value(0),
+    position: new Value(0),
+    time: new Value(0),
+    frameTime: new Value(0),
+  };
+
+  const config = {
+    duration: 200,
+    toValue: new Value(0),
+    easing: Easing.inOut(Easing.ease),
+  };
+  const decimalValueIndex = divide(yPositionOnRelease, VALUE_HEIGHT)
+  const step = cond(greaterOrEq(dragY, 0),
+    ceil(decimalValueIndex),
+    floor(decimalValueIndex),
+  )
+
+  const landingHeight = multiply(step, VALUE_HEIGHT);
+
+  return block([
+    cond(clockRunning(clock), 0, [
+      set(state.finished, 0),
+      set(state.time, 0),
+      set(state.frameTime, 0),
+      set(state.position, yPositionOnRelease),
+      set(config.toValue, landingHeight),
+      startClock(clock),
+    ]),
+    timing(clock, state, config),
+    cond(state.finished, stopClock(clock)),
+    state.position,
+  ])
+}
+
+const stripes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+class Picker extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.dragY = new Value(0)
+    this.offsetY = new Value(0)
+    this.gestureState = new Value(-1)
+    this.snapClock = new Clock()
+
+    this.onGestureEvent = event([
+      {
+        nativeEvent: {
+          translationY: this.dragY,
+          state: this.gestureState,
+        },
+      },
+    ])
+
+    const addY = add(this.dragY, this.offsetY)
+
+    this._transY = cond(
+      eq(this.gestureState, State.ACTIVE),
+      addY,
+      cond(eq(this.gestureState, State.END),
+        set(this.offsetY, runSnap(this.snapClock, addY, this.dragY)),
+        set(this.offsetY, addY),
+      ),
+    )
+  }
+
+  render() {
+    return (
+      <View style={styles.screen}>
+        <View style={styles.stripes}>
+          {stripes.map(stripe => <View style={styles.stripe} />)}
+        </View>
+        <PanGestureHandler
+          maxPointers={1}
+          onGestureEvent={this.onGestureEvent}
+          onHandlerStateChange={this.onGestureEvent}>
+          <Animated.View style={
+            [
+              styles.thing,
+              {
+                transform: [
+                  { translateY: this._transY }
+                ]
+              }
+            ]
+          } />
+        </PanGestureHandler>
+      </View>
+    )
+  }
+}
+
+export default Picker;

--- a/Example/picker/index.js
+++ b/Example/picker/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TouchableOpacity, Text } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 import Animated, { Easing } from 'react-native-reanimated';
 import { PanGestureHandler, State } from 'react-native-gesture-handler';
@@ -32,9 +33,20 @@ const {
 const VALUE_HEIGHT = 50;
 
 const styles = StyleSheet.create({
-  screen: {
+  wrapper: {
     flex: 1,
+    alignSelf: 'stretch',
+  },
+  screen: {
+    flex: 9,
     alignItems: 'center',
+  },
+  loadSection: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  loadSectionHalf: {
+    flex: 1,
   },
   thing: {
     height: VALUE_HEIGHT,
@@ -133,6 +145,10 @@ const decelerate = (yPositionOnRelease, dragY, velocityY) => {
 const stripes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 class Picker extends React.Component {
+  state = {
+    randomNumber: 0
+  }
+
   constructor(props) {
     super(props)
 
@@ -166,27 +182,48 @@ class Picker extends React.Component {
     )
   }
 
+  startLoad = () => {
+    setInterval(() => {
+        let num = 0;
+        for (let i = 0; i < 100000000; i++) {
+            num += Math.round(Math.random() / 1.69 * 100);
+        }
+        this.setState({ randomNumber: num });
+    }, 500);
+  }
+
   render() {
+    const { randomNumber } = this.state;
     return (
-      <View style={styles.screen}>
-        <View style={styles.stripes}>
-          {stripes.map(stripe => <View style={styles.stripe} />)}
+      <View style={styles.wrapper}>
+        <View style={styles.screen}>
+          <View style={styles.stripes}>
+            {stripes.map(stripe => <View style={styles.stripe} />)}
+          </View>
+          <PanGestureHandler
+            maxPointers={1}
+            onGestureEvent={this.onGestureEvent}
+            onHandlerStateChange={this.onGestureEvent}>
+            <Animated.View style={
+              [
+                styles.thing,
+                {
+                  transform: [
+                    { translateY: this._transY }
+                  ]
+                }
+              ]
+            } />
+          </PanGestureHandler>
         </View>
-        <PanGestureHandler
-          maxPointers={1}
-          onGestureEvent={this.onGestureEvent}
-          onHandlerStateChange={this.onGestureEvent}>
-          <Animated.View style={
-            [
-              styles.thing,
-              {
-                transform: [
-                  { translateY: this._transY }
-                ]
-              }
-            ]
-          } />
-        </PanGestureHandler>
+        <View style={styles.loadSection}>
+          <TouchableOpacity style={styles.loadSectionHalf} onPress={this.startLoad}>
+            <Text>Start load</Text>
+          </TouchableOpacity>
+          <View style={styles.loadSectionHalf}>
+            <Text>{randomNumber}</Text>
+          </View>
+        </View>
       </View>
     )
   }


### PR DESCRIPTION
# Swipe-picker 2

I've made some changes to the picker in the `latest-swipe-picker-1` branch of the RN app.

Here's the progress of the experiment:

- [X] Create component and story
- [ ] Make vertical column of values
- [ ] Confine it to picker area
- [X] Add gesture handler that moves it up and down
- [ ] Test in context
- [ ] Add value animations
- [ ] Add min swipe distance
- [X] Add snapping
- [ ] Add onValueChange
- [ ] Add background color animation
- [X] Add decay
- [X] Connect decay with snapping
- [ ] *Handle borders - NEXT UP*
    - [ ] When released beyond max delta, spring back to max value
    - [ ] When released beyond min delta, spring back to min value
    - [ ] Only ever display handle movement within boundaries (even if PanGestureHandler-tied value changes, only translate handle within boundaries).
    - [ ] Kill clock after exceeding limit by some threshold
- [ ] Adjust component size according to breakpoint

